### PR TITLE
Fix keepalive conflict between matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,5 +80,6 @@ jobs:
     # keepalive-workflow adds a dummy commit if there's no other action here, keeps
     # GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v1
+      if: matrix.ddev_version == 'stable'
 
 


### PR DESCRIPTION
This will make only one item in matrix try for the push that does the keepalive.