### PR TITLE
use DDEV host env

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -6,10 +6,10 @@ Some frequently asked questions about the ddev-viteserve add-on for DDEV
 2. **Do I have to use `pnpm` as my package manager?** No, we support `npm` and `yarn` as well. If `viteserve` cannot determine which package manager to use, it will helpfully ask you which of the supported choices (currently pnpm, npm and yarn) to use when installing your javascript packages.
 2. **What version of Vite works with this add-on?** This add-on has been tested with both Vite 2.9 and Vite 3. The default port is set to 5173, which is the default port for Vite's development server in 3.x. You may want to set change the setting for `VITE_PRIMARY_PORT` to 3000 if you're using Vite 2, since the port the dev server changed from 3000 to 5173 when Vite 3 came out.
 3. **Does this add-on work with Laravel's official Vite support?** It does, and the add-on has some special default behavior to support this.
-  * It sets `VITE_PROJECT_DIR=.` in your .ddev/.env file, since the location of the master Vite setting file `vite.config.js` is in the top level of your project, and not in a sub-directory. 
-  * The official Laravel plug-in requires some changes in order for hot-module-updating (HMR) to work correctly. If your `DDEV_HOSTNAME` setting is "my-laravel-app.ddev.site", your setting file would need to contain: 
+  * It sets `VITE_PROJECT_DIR=.` in your .ddev/.env file, since the location of the master Vite setting file `vite.config.js` is in the top level of your project, and not in a sub-directory.
+  * The official Laravel plug-in requires some changes in order for hot-module-updating (HMR) to work correctly. Update your project's `vite.config.js` as follows:
 
-```
+```js
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
@@ -23,7 +23,8 @@ export default defineConfig({
     server: {
         hmr: {
             protocol: "wss",
-            host: "my-laravel-app.ddev.site"
+            // if your DDEV project serves multiple hosts, update the "host" as required.
+            host: `${process.env.DDEV_HOSTNAME}`,
         }
     }
 


### PR DESCRIPTION
This PR adds a minor update to the FAQ doc.

The "host" value in the example uses the DDEV environmental variable. This makes it more dynamic if the host changes and reduces typo issues.

A note is included for multi-host sites however, I have not tested this functionality.

Also added code block language for prettier display.

Tested with DDEV `1.21.6`